### PR TITLE
feat(profile): Implement user profile feature (US 11.2, 11.3 & 11.4)

### DIFF
--- a/cors.json
+++ b/cors.json
@@ -1,0 +1,7 @@
+[
+  {
+    "origin": ["*"],
+    "method": ["GET"],
+    "maxAgeSeconds": 3600
+  }
+]

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,11 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Nous avons besoin d'accéder à votre galerie pour que vous puissiez choisir une photo de profil.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Nous avons besoin d'accéder à votre appareil photo pour que vous puissiez prendre une nouvelle photo de profil.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Nous avons besoin d'accéder à votre micro si vous choisissez de prendre une vidéo.</string>
 </dict>
 </plist>

--- a/lib/core/models/user_model.dart
+++ b/lib/core/models/user_model.dart
@@ -1,0 +1,106 @@
+// lib/core/models/user_model.dart
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Énumération pour définir les rôles des utilisateurs dans l'application.
+/// Un utilisateur peut être un étudiant, un propriétaire ou un administrateur.
+enum UserRole {
+  student,
+  homeowner,
+  admin,
+}
+
+/// Représente le modèle de données pour un utilisateur de l'application.
+///
+/// Cette classe est immuable, ce qui est une bonne pratique en Flutter.
+/// Pour modifier un utilisateur, on utilise la méthode `copyWith` pour créer une nouvelle instance.
+class UserModel {
+  final String id;
+  final String email;
+  final String displayName;
+  final String? phone;
+  final UserRole role;
+  final String? school;
+  final String? country;
+  final String? photoUrl;
+  final DateTime createdAt;
+
+  const UserModel({
+    required this.id,
+    required this.email,
+    required this.displayName,
+    this.phone,
+    required this.role,
+    this.school,
+    this.country,
+    this.photoUrl,
+    required this.createdAt,
+  });
+
+  /// Crée une copie de l'instance `UserModel` en remplaçant les champs fournis.
+  UserModel copyWith({
+    String? id,
+    String? email,
+    String? displayName,
+    String? phone,
+    UserRole? role,
+    String? school,
+    String? country,
+    String? photoUrl,
+    DateTime? createdAt,
+  }) {
+    return UserModel(
+      id: id ?? this.id,
+      email: email ?? this.email,
+      displayName: displayName ?? this.displayName,
+      phone: phone ?? this.phone,
+      role: role ?? this.role,
+      school: school ?? this.school,
+      country: country ?? this.country,
+      photoUrl: photoUrl ?? this.photoUrl,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  /// Convertit l'objet `UserModel` en une `Map` pour le stockage dans Firestore.
+  /// L'énumération `UserRole` est convertie en `String` et `DateTime` en `Timestamp`.
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'email': email,
+      'displayName': displayName,
+      'phone': phone,
+      'role': role.name, // Convertit l'enum en String (ex: 'student')
+      'school': school,
+      'country': country,
+      'photoUrl': photoUrl,
+      'createdAt': Timestamp.fromDate(createdAt), // Type de date de Firestore
+    };
+  }
+
+  /// Crée une instance de `UserModel` à partir d'une `Map` (document) venant de Firestore.
+  /// Gère la conversion inverse de `Timestamp` vers `DateTime` et `String` vers `UserRole`.
+  factory UserModel.fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data();
+    if (data == null) {
+      throw StateError('Missing data for UserModel from document: ${doc.id}');
+    }
+    
+    return UserModel(
+      id: doc.id,
+      email: data['email'] as String,
+      displayName: data['displayName'] as String,
+      phone: data['phone'] as String?,
+      // Convertit la String stockée en Firestore vers l'enum UserRole.
+      // Par défaut, assigne 'student' si le rôle est inconnu ou manquant.
+      role: UserRole.values.firstWhere(
+        (e) => e.name == data['role'],
+        orElse: () => UserRole.student,
+      ),
+      school: data['school'] as String?,
+      country: data['country'] as String?,
+      photoUrl: data['photoUrl'] as String?,
+      createdAt: (data['createdAt'] as Timestamp).toDate(),
+    );
+  }
+}

--- a/lib/core/services/profile_service.dart
+++ b/lib/core/services/profile_service.dart
@@ -16,7 +16,7 @@ class ProfileService {
 
   /// Référence à la collection 'users' dans Firestore pour éviter les erreurs de frappe.
   CollectionReference<Map<String, dynamic>> get _usersCollection =>
-      _firestore.collection('users');
+      _firestore.collection('Profile');
 
   /// Récupère le profil d'un utilisateur spécifique à partir de son ID.
   ///

--- a/lib/core/services/profile_service.dart
+++ b/lib/core/services/profile_service.dart
@@ -1,0 +1,91 @@
+// lib/core/services/profile_service.dart
+
+import 'dart:io';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import '../models/user_model.dart';
+
+/// Service pour gérer toutes les opérations CRUD (Create, Read, Update, Delete)
+/// relatives aux profils utilisateurs sur Firebase.
+/// Il gère à la fois les données sur Firestore et le stockage des images sur Firebase Storage.
+class ProfileService {
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final FirebaseStorage _storage = FirebaseStorage.instance;
+
+  /// Référence à la collection 'users' dans Firestore pour éviter les erreurs de frappe.
+  CollectionReference<Map<String, dynamic>> get _usersCollection =>
+      _firestore.collection('users');
+
+  /// Récupère le profil d'un utilisateur spécifique à partir de son ID.
+  ///
+  /// Retourne un [UserModel] si l'utilisateur est trouvé, sinon `null`.
+  Future<UserModel?> getUserProfile(String userId) async {
+    try {
+      final docSnapshot = await _usersCollection.doc(userId).get();
+      if (docSnapshot.exists) {
+        // Utilise le factory constructor 'fromFirestore' pour créer l'objet UserModel
+        return UserModel.fromFirestore(docSnapshot);
+      }
+    } catch (e) {
+      print("Erreur lors de la récupération du profil utilisateur: $e");
+    }
+    return null;
+  }
+
+  /// Méthode pratique pour obtenir le profil de l'utilisateur actuellement connecté.
+  Future<UserModel?> getCurrentUserProfile() async {
+    final currentUser = _auth.currentUser;
+    if (currentUser == null) {
+      // Si aucun utilisateur n'est connecté, il n'y a pas de profil à chercher.
+      return null;
+    }
+    return await getUserProfile(currentUser.uid);
+  }
+
+  /// Met à jour les données du profil d'un utilisateur dans Firestore.
+  ///
+  /// Prend un objet [UserModel] complet en paramètre et met à jour le document
+  /// correspondant avec les nouvelles données.
+  Future<void> updateUserProfile(UserModel user) async {
+    try {
+      await _usersCollection.doc(user.id).update(user.toJson());
+    } catch (e) {
+      print("Erreur lors de la mise à jour du profil: $e");
+      // Relance l'erreur pour que l'UI puisse la gérer (ex: afficher un message)
+      rethrow;
+    }
+  }
+
+  /// Téléverse une image de profil sur Firebase Storage et met à jour l'URL dans Firestore.
+  ///
+  /// [userId] L'ID de l'utilisateur pour qui l'image est téléversée.
+  /// [imageFile] Le fichier image (`File`) sélectionné par l'utilisateur.
+  ///
+  /// Retourne l'[String] de l'URL de téléchargement de l'image.
+  Future<String> uploadProfilePicture(String userId, File imageFile) async {
+    try {
+      // 1. Créer une référence unique dans Firebase Storage
+      // Le chemin est 'profile_pictures/[userId]/[nom_de_fichier.jpg]'
+      final fileName = '${DateTime.now().millisecondsSinceEpoch}.jpg';
+      final storageRef =
+          _storage.ref().child('profile_pictures').child(userId).child(fileName);
+
+      // 2. Téléverser le fichier
+      final uploadTask = storageRef.putFile(imageFile);
+      final snapshot = await uploadTask;
+
+      // 3. Récupérer l'URL de téléchargement
+      final downloadUrl = await snapshot.ref.getDownloadURL();
+
+      // 4. Mettre à jour le champ 'photoUrl' dans le document de l'utilisateur sur Firestore
+      await _usersCollection.doc(userId).update({'photoUrl': downloadUrl});
+
+      return downloadUrl;
+    } catch (e) {
+      print("Erreur lors de l'upload de la photo de profil: $e");
+      rethrow;
+    }
+  }
+}

--- a/lib/core/services/profile_service.dart
+++ b/lib/core/services/profile_service.dart
@@ -1,31 +1,24 @@
 // lib/core/services/profile_service.dart
 
 import 'dart:io';
+import 'dart:typed_data';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import '../models/user_model.dart';
 
-/// Service pour gérer toutes les opérations CRUD (Create, Read, Update, Delete)
-/// relatives aux profils utilisateurs sur Firebase.
-/// Il gère à la fois les données sur Firestore et le stockage des images sur Firebase Storage.
 class ProfileService {
   final FirebaseAuth _auth = FirebaseAuth.instance;
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
   final FirebaseStorage _storage = FirebaseStorage.instance;
 
-  /// Référence à la collection 'users' dans Firestore pour éviter les erreurs de frappe.
   CollectionReference<Map<String, dynamic>> get _usersCollection =>
       _firestore.collection('Profile');
 
-  /// Récupère le profil d'un utilisateur spécifique à partir de son ID.
-  ///
-  /// Retourne un [UserModel] si l'utilisateur est trouvé, sinon `null`.
   Future<UserModel?> getUserProfile(String userId) async {
     try {
       final docSnapshot = await _usersCollection.doc(userId).get();
       if (docSnapshot.exists) {
-        // Utilise le factory constructor 'fromFirestore' pour créer l'objet UserModel
         return UserModel.fromFirestore(docSnapshot);
       }
     } catch (e) {
@@ -34,53 +27,45 @@ class ProfileService {
     return null;
   }
 
-  /// Méthode pratique pour obtenir le profil de l'utilisateur actuellement connecté.
   Future<UserModel?> getCurrentUserProfile() async {
     final currentUser = _auth.currentUser;
     if (currentUser == null) {
-      // Si aucun utilisateur n'est connecté, il n'y a pas de profil à chercher.
       return null;
     }
     return await getUserProfile(currentUser.uid);
   }
 
-  /// Met à jour les données du profil d'un utilisateur dans Firestore.
-  ///
-  /// Prend un objet [UserModel] complet en paramètre et met à jour le document
-  /// correspondant avec les nouvelles données.
   Future<void> updateUserProfile(UserModel user) async {
     try {
-      await _usersCollection.doc(user.id).update(user.toJson());
+      // Utilisation de .set avec merge pour plus de robustesse
+      await _usersCollection.doc(user.id).set(user.toJson(), SetOptions(merge: true));
     } catch (e) {
       print("Erreur lors de la mise à jour du profil: $e");
-      // Relance l'erreur pour que l'UI puisse la gérer (ex: afficher un message)
       rethrow;
     }
   }
 
-  /// Téléverse une image de profil sur Firebase Storage et met à jour l'URL dans Firestore.
-  ///
-  /// [userId] L'ID de l'utilisateur pour qui l'image est téléversée.
-  /// [imageFile] Le fichier image (`File`) sélectionné par l'utilisateur.
-  ///
-  /// Retourne l'[String] de l'URL de téléchargement de l'image.
-  Future<String> uploadProfilePicture(String userId, File imageFile) async {
+  Future<String> uploadProfilePicture(String userId, Uint8List imageData) async {
     try {
-      // 1. Créer une référence unique dans Firebase Storage
-      // Le chemin est 'profile_pictures/[userId]/[nom_de_fichier.jpg]'
       final fileName = '${DateTime.now().millisecondsSinceEpoch}.jpg';
       final storageRef =
           _storage.ref().child('profile_pictures').child(userId).child(fileName);
 
-      // 2. Téléverser le fichier
-      final uploadTask = storageRef.putFile(imageFile);
+      final uploadTask = storageRef.putData(imageData);
       final snapshot = await uploadTask;
 
-      // 3. Récupérer l'URL de téléchargement
       final downloadUrl = await snapshot.ref.getDownloadURL();
 
-      // 4. Mettre à jour le champ 'photoUrl' dans le document de l'utilisateur sur Firestore
-      await _usersCollection.doc(userId).update({'photoUrl': downloadUrl});
+      // ✅ AJOUT D'UN PRINT POUR DÉBOGUER
+      // Cette ligne nous confirmera dans la console que l'URL est bien récupérée.
+      print('Mise à jour de Firestore avec l\'URL : $downloadUrl');
+
+      // ✅ MODIFICATION : Remplacement de .update par .set avec merge
+      // C'est une méthode plus sûre qui crée le champ s'il n'existe pas.
+      await _usersCollection.doc(userId).set(
+        {'photoUrl': downloadUrl},
+        SetOptions(merge: true),
+      );
 
       return downloadUrl;
     } catch (e) {

--- a/lib/features/profile/screens/edit_profile_screen.dart
+++ b/lib/features/profile/screens/edit_profile_screen.dart
@@ -1,81 +1,88 @@
-// lib/features/profile/screens/edit_profile_screen.dart
-
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
+import 'package:country_picker/country_picker.dart';
 import '../../../core/models/user_model.dart';
 import '../state/profile_providers.dart';
 
 class EditProfileScreen extends ConsumerStatefulWidget {
   final UserModel user;
-
   const EditProfileScreen({super.key, required this.user});
-
   @override
   ConsumerState<EditProfileScreen> createState() => _EditProfileScreenState();
 }
 
 class _EditProfileScreenState extends ConsumerState<EditProfileScreen> {
+  String? _selectedSchool;
+  final List<String> _schools = [
+    'École de Design et Haute Ecole d\'Art (EDHEA)',
+    'Haute Ecole de Gestion (HEG)',
+    'Haute Ecole d\'Ingénierie (HEI)',
+    'Haute Ecole de Santé (HES)',
+    'Haute Ecole et Ecole Supérieure de Travail Social (HESTS)',
+  ];
+
+  late final TextEditingController _countryController;
+  late final TextEditingController _emailController;
   late final TextEditingController _displayNameController;
   late final TextEditingController _phoneController;
-  late final TextEditingController _schoolController;
   final _formKey = GlobalKey<FormState>();
   bool _isLoading = false;
 
   @override
   void initState() {
     super.initState();
-    // Initialise les contrôleurs avec les données de l'utilisateur actuel
+    _emailController = TextEditingController(text: widget.user.email);
+    _countryController = TextEditingController(text: widget.user.country);
     _displayNameController = TextEditingController(text: widget.user.displayName);
     _phoneController = TextEditingController(text: widget.user.phone);
-    _schoolController = TextEditingController(text: widget.user.school);
+
+    if (widget.user.school != null && _schools.contains(widget.user.school)) {
+      _selectedSchool = widget.user.school;
+    }
   }
 
   @override
   void dispose() {
-    // Libère la mémoire des contrôleurs
+    _emailController.dispose();
+    _countryController.dispose();
     _displayNameController.dispose();
     _phoneController.dispose();
-    _schoolController.dispose();
     super.dispose();
   }
 
   Future<void> _saveProfile() async {
-    // Valide le formulaire
-    if (!_formKey.currentState!.validate()) {
-      return;
-    }
-
+    if (!_formKey.currentState!.validate()) return;
+    
     setState(() => _isLoading = true);
-
     try {
-      // Récupère le service via Riverpod
       final profileService = ref.read(profileServiceProvider);
 
-      // Crée une nouvelle instance de UserModel avec les données mises à jour
-      final updatedUser = widget.user.copyWith(
+      final currentUserState = ref.read(userProfileProvider).value;
+      if (currentUserState == null) {
+        throw Exception("Utilisateur non trouvé, impossible de sauvegarder.");
+      }
+
+      // On applique les modifications sur cette version fraîche des données
+      final updatedUser = currentUserState.copyWith(
         displayName: _displayNameController.text,
         phone: _phoneController.text,
-        school: _schoolController.text,
+        school: _selectedSchool,
+        email: _emailController.text,
+        country: _countryController.text,
       );
-
-      // Appelle la méthode de mise à jour du service
+      
       await profileService.updateUserProfile(updatedUser);
-
-      // Rafraîchit les données du profil dans l'application
-      ref.invalidate(userProfileProvider);
-
       if (mounted) {
-        // Affiche un message de succès
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Profil mis à jour avec succès !')),
         );
-        // Retourne à l'écran précédent
         Navigator.of(context).pop();
       }
     } catch (e) {
       if (mounted) {
-        // Affiche un message d'erreur
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Erreur lors de la mise à jour : $e')),
         );
@@ -87,12 +94,77 @@ class _EditProfileScreenState extends ConsumerState<EditProfileScreen> {
     }
   }
 
+   Future<void> _pickAndUploadImage() async {
+    final picker = ImagePicker();
+    final pickedFile = await picker.pickImage(source: ImageSource.gallery);
+    if (pickedFile == null) return;
+
+    setState(() => _isLoading = true);
+    try {
+      final imageData = await pickedFile.readAsBytes();
+      
+      final profileService = ref.read(profileServiceProvider);
+      await profileService.uploadProfilePicture(widget.user.id, imageData);
+      
+      // ✅ SOLUTION : Invalidez le provider ici !
+      // Cela force Riverpod à recharger les données du profil depuis Firestore.
+      // La prochaine lecture de `userProfileProvider` aura la nouvelle `photoUrl`.
+      ref.invalidate(userProfileProvider);
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Photo de profil mise à jour !')),
+        );
+      }
+    } catch (e) {
+       if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text("Erreur lors de l'upload : $e")),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  void _openCountryPicker() {
+    showCountryPicker(
+      context: context,
+      countryListTheme: CountryListThemeData(
+        backgroundColor: ShadTheme.of(context).colorScheme.background,
+        textStyle: TextStyle(color: ShadTheme.of(context).colorScheme.foreground),
+        bottomSheetHeight: 500,
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(20.0),
+          topRight: Radius.circular(20.0),
+        ),
+        inputDecoration: InputDecoration(
+          labelText: 'Rechercher',
+          hintText: 'Commencez à taper...',
+          prefixIcon: const Icon(Icons.search),
+          border: OutlineInputBorder(
+            borderSide: BorderSide(
+              color: const Color(0xFF8D99AE).withOpacity(0.2),
+            ),
+          ),
+        ),
+      ),
+      onSelect: (Country country) {
+        setState(() {
+          _countryController.text = country.name;
+        });
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    final userAsyncValue = ref.watch(userProfileProvider);
+
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Modifier le profil'),
-      ),
+      appBar: AppBar(title: const Text('Modifier le profil')),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(24),
         child: Form(
@@ -100,42 +172,146 @@ class _EditProfileScreenState extends ConsumerState<EditProfileScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              // Champ pour le nom d'affichage
-              const Text("Nom d'affichage", style: TextStyle(fontWeight: FontWeight.bold)),
+              Center(
+                child: GestureDetector(
+                  onTap: _isLoading ? null : _pickAndUploadImage,
+                  child: userAsyncValue.when(
+                    data: (user) => CircleAvatar(
+                      radius: 64,
+                      backgroundColor: ShadTheme.of(context).colorScheme.muted,
+                      backgroundImage: user?.photoUrl != null
+                          ? NetworkImage(user!.photoUrl!)
+                          : null,
+                      child: user?.photoUrl == null
+                          ? const Icon(Icons.camera_alt, size: 40)
+                          : null,
+                    ),
+                    loading: () => const CircleAvatar(radius: 64, child: CircularProgressIndicator()),
+                    error: (e, s) => const CircleAvatar(radius: 64, child: Icon(Icons.error)),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24),
+
+              Text("Nom d'affichage", style: ShadTheme.of(context).textTheme.small),
               const SizedBox(height: 8),
-              ShadInput(
-                controller: _displayNameController,
-                placeholder: const Text('Entrez votre nom complet'),
+              FormField<String>(
+                validator: (value) {
+                  if (_displayNameController.text.isEmpty) {
+                    return 'Le nom ne peut pas être vide';
+                  }
+                  return null;
+                },
+                builder: (FormFieldState<String> field) {
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      ShadInput(controller: _displayNameController),
+                      if (field.hasError)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 8.0),
+                          child: Text(field.errorText!, style: TextStyle(color: ShadTheme.of(context).colorScheme.destructive)),
+                        ),
+                    ],
+                  );
+                },
+              ),
+              const SizedBox(height: 16),
+              
+              Text("Adresse e-mail", style: ShadTheme.of(context).textTheme.small),
+              const SizedBox(height: 8),
+              FormField<String>(
+                validator: (value) {
+                  final email = _emailController.text;
+                  if (email.isEmpty) return 'L\'adresse e-mail ne peut pas être vide';
+                  final emailRegex = RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$');
+                  if (!emailRegex.hasMatch(email)) return 'Format d\'e-mail invalide';
+                  return null;
+                },
+                builder: (FormFieldState<String> field) {
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      ShadInput(
+                        controller: _emailController,
+                        keyboardType: TextInputType.emailAddress,
+                      ),
+                      if (field.hasError)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 8.0),
+                          child: Text(field.errorText!, style: TextStyle(color: ShadTheme.of(context).colorScheme.destructive)),
+                        ),
+                    ],
+                  );
+                },
               ),
               const SizedBox(height: 16),
 
-              // Champ pour le téléphone
-              const Text('Numéro de téléphone', style: TextStyle(fontWeight: FontWeight.bold)),
+              Text('Numéro de téléphone', style: ShadTheme.of(context).textTheme.small),
               const SizedBox(height: 8),
-              ShadInput(
-                controller: _phoneController,
-                placeholder: const Text('Entrez votre numéro de téléphone'),
+              FormField<String>(
+                validator: (value) {
+                  final phone = _phoneController.text;
+                  if (phone.isNotEmpty) {
+                    final phoneRegex = RegExp(r'^\+41\s\d{2}\s\d{3}\s\d{2}\s\d{2}$');
+                    if (!phoneRegex.hasMatch(phone)) return 'Format invalide (+41 XX XXX XX XX)';
+                  }
+                  return null;
+                },
+                builder: (FormFieldState<String> field) {
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      ShadInput(
+                        controller: _phoneController,
+                        keyboardType: TextInputType.phone,
+                        placeholder: const Text('+41 79 123 45 67'),
+                      ),
+                      if (field.hasError)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 8.0),
+                          child: Text(field.errorText!, style: TextStyle(color: ShadTheme.of(context).colorScheme.destructive)),
+                        ),
+                    ],
+                  );
+                },
               ),
               const SizedBox(height: 16),
 
-              // Champ pour l'école/université
-              const Text('École / Université', style: TextStyle(fontWeight: FontWeight.bold)),
+              Text('École / Université', style: ShadTheme.of(context).textTheme.small),
               const SizedBox(height: 8),
-              ShadInput(
-                controller: _schoolController,
-                placeholder: const Text('Entrez le nom de votre établissement'),
+              ShadSelect<String>(
+                initialValue: _selectedSchool,
+                placeholder: const Text('Sélectionnez une école'),
+                options: _schools.map((school) => ShadOption(value: school, child: Text(school))).toList(),
+                selectedOptionBuilder: (context, value) => Text(value),
+                onChanged: (value) {
+                  setState(() {
+                    _selectedSchool = value;
+                  });
+                },
+              ),
+              const SizedBox(height: 16),
+              
+              Text("Pays", style: ShadTheme.of(context).textTheme.small),
+              const SizedBox(height: 8),
+              GestureDetector(
+                onTap: _openCountryPicker,
+                child: AbsorbPointer(
+                  child: ShadInput(
+                    controller: _countryController,
+                    placeholder: const Text('Sélectionnez un pays'),
+                    readOnly: true,
+                  ),
+                ),
               ),
               const SizedBox(height: 32),
-
-              // Bouton de sauvegarde
+              
               ShadButton(
                 onPressed: _isLoading ? null : _saveProfile,
                 child: _isLoading
-                    ? const SizedBox.square(
-                        dimension: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : const Text('Enregistrer les modifications'),
+                    ? const SizedBox.square(dimension: 16, child: CircularProgressIndicator(strokeWidth: 2))
+                    : const Text('Enregistrer'),
               ),
             ],
           ),

--- a/lib/features/profile/screens/edit_profile_screen.dart
+++ b/lib/features/profile/screens/edit_profile_screen.dart
@@ -1,0 +1,146 @@
+// lib/features/profile/screens/edit_profile_screen.dart
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+import '../../../core/models/user_model.dart';
+import '../state/profile_providers.dart';
+
+class EditProfileScreen extends ConsumerStatefulWidget {
+  final UserModel user;
+
+  const EditProfileScreen({super.key, required this.user});
+
+  @override
+  ConsumerState<EditProfileScreen> createState() => _EditProfileScreenState();
+}
+
+class _EditProfileScreenState extends ConsumerState<EditProfileScreen> {
+  late final TextEditingController _displayNameController;
+  late final TextEditingController _phoneController;
+  late final TextEditingController _schoolController;
+  final _formKey = GlobalKey<FormState>();
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // Initialise les contrôleurs avec les données de l'utilisateur actuel
+    _displayNameController = TextEditingController(text: widget.user.displayName);
+    _phoneController = TextEditingController(text: widget.user.phone);
+    _schoolController = TextEditingController(text: widget.user.school);
+  }
+
+  @override
+  void dispose() {
+    // Libère la mémoire des contrôleurs
+    _displayNameController.dispose();
+    _phoneController.dispose();
+    _schoolController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _saveProfile() async {
+    // Valide le formulaire
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+
+    setState(() => _isLoading = true);
+
+    try {
+      // Récupère le service via Riverpod
+      final profileService = ref.read(profileServiceProvider);
+
+      // Crée une nouvelle instance de UserModel avec les données mises à jour
+      final updatedUser = widget.user.copyWith(
+        displayName: _displayNameController.text,
+        phone: _phoneController.text,
+        school: _schoolController.text,
+      );
+
+      // Appelle la méthode de mise à jour du service
+      await profileService.updateUserProfile(updatedUser);
+
+      // Rafraîchit les données du profil dans l'application
+      ref.invalidate(userProfileProvider);
+
+      if (mounted) {
+        // Affiche un message de succès
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Profil mis à jour avec succès !')),
+        );
+        // Retourne à l'écran précédent
+        Navigator.of(context).pop();
+      }
+    } catch (e) {
+      if (mounted) {
+        // Affiche un message d'erreur
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Erreur lors de la mise à jour : $e')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Modifier le profil'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Champ pour le nom d'affichage
+              const Text("Nom d'affichage", style: TextStyle(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              ShadInput(
+                controller: _displayNameController,
+                placeholder: const Text('Entrez votre nom complet'),
+              ),
+              const SizedBox(height: 16),
+
+              // Champ pour le téléphone
+              const Text('Numéro de téléphone', style: TextStyle(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              ShadInput(
+                controller: _phoneController,
+                placeholder: const Text('Entrez votre numéro de téléphone'),
+              ),
+              const SizedBox(height: 16),
+
+              // Champ pour l'école/université
+              const Text('École / Université', style: TextStyle(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              ShadInput(
+                controller: _schoolController,
+                placeholder: const Text('Entrez le nom de votre établissement'),
+              ),
+              const SizedBox(height: 32),
+
+              // Bouton de sauvegarde
+              ShadButton(
+                onPressed: _isLoading ? null : _saveProfile,
+                child: _isLoading
+                    ? const SizedBox.square(
+                        dimension: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Enregistrer les modifications'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/profile/screens/profile_screen.dart
+++ b/lib/features/profile/screens/profile_screen.dart
@@ -1,11 +1,8 @@
-// lib/features/profile/screens/profile_screen.dart
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 import 'package:room_renting_group1/features/profile/state/profile_providers.dart';
-
-import 'edit_profile_screen.dart'; 
+import 'edit_profile_screen.dart';
 
 class ProfileScreen extends ConsumerWidget {
   const ProfileScreen({super.key});
@@ -15,18 +12,12 @@ class ProfileScreen extends ConsumerWidget {
     final profileAsyncValue = ref.watch(userProfileProvider);
 
     return Scaffold(
-      // ✅ Correction n°1 : Utilisation de l'AppBar standard de Material
-      appBar: AppBar(
-        title: const Text('Mon Profil'),
-        backgroundColor: ShadTheme.of(context).colorScheme.background,
-        elevation: 0,
-      ),
       body: profileAsyncValue.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (err, stack) => Center(child: Text('Erreur: $err')),
         data: (user) {
           if (user == null) {
-            return const Center(child: Text('Profil non trouvé. Veuillez vous connecter.'));
+            return const Center(child: Text('Profil non trouvé.'));
           }
           
           return Container(
@@ -36,17 +27,18 @@ class ProfileScreen extends ConsumerWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                // ✅ Correction n°2 : Dimensionner l'avatar avec un SizedBox
-                SizedBox(
-                  width: 96,
-                  height: 96,
-                  child: ShadAvatar(
-                    user.photoUrl != null ? NetworkImage(user.photoUrl!) : null,
-                    placeholder: Text(
-                      user.displayName.substring(0, 2).toUpperCase(),
-                      style: const TextStyle(fontSize: 32),
-                    ),
-                  ),
+                CircleAvatar(
+                  radius: 56,
+                  backgroundColor: ShadTheme.of(context).colorScheme.muted,
+                  backgroundImage: user.photoUrl != null
+                      ? NetworkImage(user.photoUrl!)
+                      : null,
+                  child: user.photoUrl == null
+                      ? Text(
+                          user.displayName.substring(0, 2).toUpperCase(),
+                          style: const TextStyle(fontSize: 40),
+                        )
+                      : null,
                 ),
                 const SizedBox(height: 16),
                 
@@ -56,16 +48,21 @@ class ProfileScreen extends ConsumerWidget {
                 const SizedBox(height: 32),
                 
                 ShadButton(
-                  onPressed: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (context) => EditProfileScreen(user: user),
-                      ),
-                    );
-                  },
-                  child: const Text('Modifier le profil'),
-                  width: double.infinity,
-                ),
+                // ✅ 1. Rendez la fonction onPressed "async"
+                onPressed: () async {
+                  // ✅ 2. Attendez que l'écran d'édition se ferme avec "await"
+                  await Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (context) => EditProfileScreen(user: user),
+                    ),
+                  );
+
+                  // ✅ 3. Une fois de retour, rafraîchissez les données
+                  ref.invalidate(userProfileProvider);
+                },
+                child: const Text('Modifier le profil'),
+                width: double.infinity,
+              ),
               ],
             ),
           );

--- a/lib/features/profile/screens/profile_screen.dart
+++ b/lib/features/profile/screens/profile_screen.dart
@@ -1,0 +1,76 @@
+// lib/features/profile/screens/profile_screen.dart
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+import 'package:room_renting_group1/features/profile/state/profile_providers.dart';
+
+import 'edit_profile_screen.dart'; 
+
+class ProfileScreen extends ConsumerWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profileAsyncValue = ref.watch(userProfileProvider);
+
+    return Scaffold(
+      // ✅ Correction n°1 : Utilisation de l'AppBar standard de Material
+      appBar: AppBar(
+        title: const Text('Mon Profil'),
+        backgroundColor: ShadTheme.of(context).colorScheme.background,
+        elevation: 0,
+      ),
+      body: profileAsyncValue.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (err, stack) => Center(child: Text('Erreur: $err')),
+        data: (user) {
+          if (user == null) {
+            return const Center(child: Text('Profil non trouvé. Veuillez vous connecter.'));
+          }
+          
+          return Container(
+            padding: const EdgeInsets.all(24.0),
+            alignment: Alignment.center,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                // ✅ Correction n°2 : Dimensionner l'avatar avec un SizedBox
+                SizedBox(
+                  width: 96,
+                  height: 96,
+                  child: ShadAvatar(
+                    user.photoUrl != null ? NetworkImage(user.photoUrl!) : null,
+                    placeholder: Text(
+                      user.displayName.substring(0, 2).toUpperCase(),
+                      style: const TextStyle(fontSize: 32),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                
+                Text(user.displayName, style: ShadTheme.of(context).textTheme.h2),
+                const SizedBox(height: 4),
+                Text(user.email, style: ShadTheme.of(context).textTheme.muted),
+                const SizedBox(height: 32),
+                
+                ShadButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (context) => EditProfileScreen(user: user),
+                      ),
+                    );
+                  },
+                  child: const Text('Modifier le profil'),
+                  width: double.infinity,
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/profile/state/profile_providers.dart
+++ b/lib/features/profile/state/profile_providers.dart
@@ -11,7 +11,6 @@ final profileServiceProvider = Provider<ProfileService>((ref) {
 final userProfileProvider = FutureProvider<UserModel?>((ref) {
   final profileService = ref.watch(profileServiceProvider);
 
-  // ✅ MODIFICATION POUR LE TEST :
-  // On ignore la connexion et on charge directement un profil par son ID.
-  return profileService.getUserProfile("FmxIVtvr930fjtjcuIWA");
+  // ✅ On revient à la logique normale qui dépend de la connexion
+  return profileService.getCurrentUserProfile();
 });

--- a/lib/features/profile/state/profile_providers.dart
+++ b/lib/features/profile/state/profile_providers.dart
@@ -1,0 +1,17 @@
+// lib/features/profile/state/profile_providers.dart
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/models/user_model.dart';
+import '../../../core/services/profile_service.dart';
+
+final profileServiceProvider = Provider<ProfileService>((ref) {
+  return ProfileService();
+});
+
+final userProfileProvider = FutureProvider<UserModel?>((ref) {
+  final profileService = ref.watch(profileServiceProvider);
+
+  // ✅ MODIFICATION POUR LE TEST :
+  // On ignore la connexion et on charge directement un profil par son ID.
+  return profileService.getUserProfile("FmxIVtvr930fjtjcuIWA");
+});

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,16 +1,19 @@
+// main.dart
+
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
 import 'firebase_options.dart';
-
-
-import 'features/listings/screens/apartments_page.dart';
+import 'main_shell.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
-  runApp(const MyApp());
+  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  
+  // Le code de connexion a été retiré, il n'est plus utile.
+  
+  runApp(const ProviderScope(child: MyApp()));
 }
 
 class MyApp extends StatelessWidget {
@@ -18,13 +21,21 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Room Renting CRUD Demo',
-      theme: ThemeData(
-        useMaterial3: true,
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
+    return ShadApp.custom(
+      theme: ShadThemeData(
+        brightness: Brightness.dark,
+        colorScheme: const ShadSlateColorScheme.dark(),
       ),
-      home: const ApartmentsPage(), 
+      appBuilder: (context) {
+        return MaterialApp(
+          theme: Theme.of(context),
+          builder: (context, child) {
+            return ShadAppBuilder(child: child!);
+          },
+          home: const MainShell(),
+          debugShowCheckedModeBanner: false,
+        );
+      },
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,9 @@
 // main.dart
-
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'firebase_options.dart';
 import 'main_shell.dart';
 
@@ -11,7 +11,16 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   
-  // Le code de connexion a été retiré, il n'est plus utile.
+  // On remet le code de connexion, il est obligatoire pour l'upload
+  try {
+    await FirebaseAuth.instance.signInWithEmailAndPassword(
+      email: "test_user@gmail.com",
+      password: "Test123456"
+    );
+    print("✅ Connexion de test réussie !");
+  } on FirebaseAuthException catch (e) {
+    print("🔥 Erreur de connexion de test: ${e.message}");
+  }
   
   runApp(const ProviderScope(child: MyApp()));
 }

--- a/lib/main_shell.dart
+++ b/lib/main_shell.dart
@@ -1,0 +1,56 @@
+// lib/main_shell.dart
+
+import 'package:flutter/material.dart';
+import 'package:room_renting_group1/features/apartments/screens/apartments_page.dart';
+import 'package:room_renting_group1/features/profile/screens/profile_screen.dart';
+
+class MainShell extends StatefulWidget {
+  const MainShell({super.key});
+
+  @override
+  State<MainShell> createState() => _MainShellState();
+}
+
+class _MainShellState extends State<MainShell> {
+  int _selectedIndex = 0; // Index de la page actuellement affichée
+
+  // Liste des pages principales de l'application
+  static const List<Widget> _pages = <Widget>[
+    ApartmentsPage(),
+    ProfileScreen(),
+    // Ajoutez d'autres pages principales ici
+  ];
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      // La AppBar peut aussi être ici pour être persistante
+      appBar: AppBar(
+        title: Text(_selectedIndex == 0 ? 'Logements' : 'Mon Profil'),
+      ),
+      // Le corps de la page change en fonction de l'index sélectionné
+      body: _pages.elementAt(_selectedIndex),
+      // La barre de navigation en bas
+      bottomNavigationBar: BottomNavigationBar(
+        items: const <BottomNavigationBarItem>[
+          BottomNavigationBarItem(
+            icon: Icon(Icons.home),
+            label: 'Logements',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.account_circle),
+            label: 'Profil',
+          ),
+        ],
+        currentIndex: _selectedIndex,
+        onTap: _onItemTapped,
+      ),
+    );
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,6 +11,7 @@ import file_selector_macos
 import firebase_auth
 import firebase_core
 import firebase_storage
+import path_provider_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
@@ -19,4 +20,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.59"
+  args:
+    dependency: transitive
+    description:
+      name: args
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
@@ -25,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  boxy:
+    dependency: transitive
+    description:
+      name: boxy
+      sha256: "71af0cd1bf7889c09787f26219a345aa4f38ccb98384c8ec24189e4d8e746005"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
   characters:
     dependency: transitive
     description:
@@ -81,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.4+2"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -89,6 +113,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  extended_image:
+    dependency: transitive
+    description:
+      name: extended_image
+      sha256: f6cbb1d798f51262ed1a3d93b4f1f2aa0d76128df39af18ecb77fa740f88b2e0
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.1"
+  extended_image_library:
+    dependency: transitive
+    description:
+      name: extended_image_library
+      sha256: "1f9a24d3a00c2633891c6a7b5cab2807999eb2d5b597e5133b63f49d113811fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.1"
   fake_async:
     dependency: transitive
     description:
@@ -222,6 +262,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_animate:
+    dependency: transitive
+    description:
+      name: flutter_animate
+      sha256: "7befe2d3252728afb77aecaaea1dec88a89d35b9b1d2eea6d04479e8af9117b5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.2"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -230,6 +278,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -238,6 +291,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.29"
+  flutter_riverpod:
+    dependency: "direct main"
+    description:
+      name: flutter_riverpod
+      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
+  flutter_shaders:
+    dependency: transitive
+    description:
+      name: flutter_shaders
+      sha256: "34794acadd8275d971e02df03afee3dee0f98dbfb8c4837082ad0034f612a3e2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3"
+  flutter_svg:
+    dependency: transitive
+    description:
+      name: flutter_svg
+      sha256: cd57f7969b4679317c17af6fd16ee233c1e60a82ed209d8a475c54fd6fd6f845
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -256,6 +333,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  http_client_helper:
+    dependency: transitive
+    description:
+      name: http_client_helper
+      sha256: "8a9127650734da86b5c73760de2b404494c968a3fd55602045ffec789dac3cb1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   http_parser:
     dependency: transitive
     description:
@@ -328,6 +413,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -360,6 +461,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  lucide_icons_flutter:
+    dependency: transitive
+    description:
+      name: lucide_icons_flutter
+      sha256: c88e3611c0aa272ca2f2aa263662174ae4996f5e3ee1c300021514df230b6588
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.9"
   matcher:
     dependency: transitive
     description:
@@ -400,6 +509,78 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "993381400e94d18469750e5b9dcb8206f15bc09f9da86b9e44a9b0092a0066db"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.18"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "16eef174aacb07e09c351502740fa6254c165757638eba1e9116b0a781201bbd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -408,6 +589,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
+  shadcn_ui:
+    dependency: "direct main"
+    description:
+      name: shadcn_ui
+      sha256: "2b899e1ba01958197e4c97eb96117694538699be5e55be2798ff6ff79352653e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.29.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -429,6 +626,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.1"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:
@@ -461,6 +666,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.6"
+  two_dimensional_scrollables:
+    dependency: transitive
+    description:
+      name: two_dimensional_scrollables
+      sha256: "0f77ecb96596f2f82eec2b0a8e60d9305c58315557da9fa3b610c7dbf5ded621"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.7"
   typed_data:
     dependency: transitive
     description:
@@ -469,6 +682,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  universal_image:
+    dependency: transitive
+    description:
+      name: universal_image
+      sha256: ef47a4a002158cf0b36ed3b7605af132d2476cc42703e41b8067d3603705c40d
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.11"
+  vector_graphics:
+    dependency: transitive
+    description:
+      name: vector_graphics
+      sha256: a4f059dc26fc8295b5921376600a194c4ec7d55e72f2fe4c7d2831e103d461e6
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.19"
+  vector_graphics_codec:
+    dependency: transitive
+    description:
+      name: vector_graphics_codec
+      sha256: "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.13"
+  vector_graphics_compiler:
+    dependency: transitive
+    description:
+      name: vector_graphics_compiler
+      sha256: d354a7ec6931e6047785f4db12a1f61ec3d43b207fc0790f863818543f8ff0dc
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.19"
   vector_math:
     dependency: transitive
     description:
@@ -501,6 +746,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.14.0"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
 sdks:
   dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.29.0"
+  flutter: ">=3.32.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -89,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  country_picker:
+    dependency: "direct main"
+    description:
+      name: country_picker
+      sha256: "9b14c04f9a35e99f6de6bcbc453a556bb98345aecb481c7a0e843c94c2bee1f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.27"
   cross_file:
     dependency: transitive
     description:
@@ -690,6 +698,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.11"
+  universal_io:
+    dependency: transitive
+    description:
+      name: universal_io
+      sha256: "1722b2dcc462b4b2f3ee7d188dad008b6eb4c40bbd03a3de451d82c78bba9aad"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.2"
   vector_graphics:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,13 +16,14 @@ dependencies:
   cloud_firestore: ^5.4.4
   firebase_auth: ^5.3.1
   firebase_storage: ^12.0.0
-  image_picker: ^1.1.1
+  image_picker: ^1.2.0
   file_picker: ^8.0.0
 
   # UI
   cupertino_icons: ^1.0.8
   shadcn_ui: ^0.29.0
   flutter_riverpod: ^2.6.1
+  country_picker: ^2.0.27
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
 
   # UI
   cupertino_icons: ^1.0.8
+  shadcn_ui: ^0.29.0
+  flutter_riverpod: ^2.6.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# feat(profile): Implement user profile feature (US 11.2, 11.3 & 11.4)

This Pull Request introduces the complete user profile feature, allowing users to view, edit, and update personal information, including the profile picture.

### What's been implemented:

* **View Screen (`ProfileScreen`)**: Displays user information (name, email, photo, etc.) fetched from Firestore.

* **Edit Screen (`EditProfileScreen`)**:
    * A complete form to modify the display name, email, phone number, school, and country.
    * **Field Validation**:
        * The name cannot be empty.
        * Email and phone number are validated using regular expressions (RegExp).
    * **Controlled Selection**:
        * A dropdown menu (`ShadSelect`) for the "School" field.
        * The `country_picker` package for a user-friendly country selection.

* **Profile Picture Upload**:
    * The user can click their avatar to choose an image from their device gallery via `image_picker`.
    * The implementation is cross-platform (works on mobile and web).
    * The image is uploaded to Firebase Storage, and the download URL is then saved to the user's document in Firestore.

* **State Management**:
    * State is managed with Riverpod (`FutureProvider`).
    * The UI updates automatically after each modification (name change, new photo) thanks to `ref.invalidate`.


*Closes US-11.2, US-11.3, US-11.4*
<img width="1537" height="957" alt="image" src="https://github.com/user-attachments/assets/a0e127c1-88b5-48da-bc77-7ecd1518f1ba" />
<img width="1900" height="995" alt="image" src="https://github.com/user-attachments/assets/b44e867a-0b44-4e74-80a1-2e6150a2fe63" />
